### PR TITLE
Fix weight propagation

### DIFF
--- a/contracts/eosio.system/voting.cpp
+++ b/contracts/eosio.system/voting.cpp
@@ -476,15 +476,8 @@ namespace eosiosystem {
    void system_contract::propagate_weight_change(const voter_info &voter) {
      eosio_assert( voter.proxy == 0 || !voter.is_proxy, "account registered as a proxy is not allowed to use a proxy");
      
-     //getting all active producers
-     auto totalProds = 0;
-     for (const auto &prod : _producers) {
-       if(prod.active()) { 
-         totalProds++;
-       }
-     }
      auto totalStake = double(voter.staked) + voter.proxied_vote_weight;
-     double new_weight = inverseVoteWeight(totalStake, totalProds);
+     double new_weight = inverseVoteWeight(totalStake, voter.producers.size());
     
      if (voter.proxy) {
        auto &proxy = _voters.get(voter.proxy, "proxy not found"); // data corruption
@@ -495,7 +488,7 @@ namespace eosiosystem {
        for (auto acnt : voter.producers) {
          auto &pitr = _producers.get(acnt, "producer not found"); // data corruption
          _producers.modify(pitr, 0, [&](auto &p) {
-           p.total_votes = new_weight;
+           p.total_votes += new_weight;
          });
        }
      }


### PR DESCRIPTION
This is a fix for Issue #40 by using the proposed behavior. It changes the weight calculation to be based on the number of producers voted VS total active producers. ( only for the weight propagation cases )