### PR TITLE
Fix claimrewards never validating for payout

### DIFF
--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -47,8 +47,8 @@ void system_contract::onblock(block_timestamp timestamp, account_name producer)
         return;
     }
         
-    // if (_gstate.last_pervote_bucket_fill == 0) /// start the presses
-    //     _gstate.last_pervote_bucket_fill = current_time();
+    if (_gstate.last_pervote_bucket_fill == 0) /// start the presses
+        _gstate.last_pervote_bucket_fill = current_time();
 
     /**
     * At startup the initial producer may not be one that is registered / elected


### PR DESCRIPTION
This is a fix for claim rewards. 

The validation checks that _gstate.last_pervote_bucket_fill > 0, BUT the value only ever gets updated IF it already is >0. 
Since the default value is 0 and it never gets updated, validation never checks out and payout is 0. 

This un-commented code will allow the value to change from the default 0 to the initial block production.

This is tested by unit 27 mentioned in issue #17 