### PR TITLE
Use TLOS prefix to check if authority is a pubkey

### DIFF
--- a/programs/teclos/main.cpp
+++ b/programs/teclos/main.cpp
@@ -602,7 +602,7 @@ authority parse_json_authority(const std::string& authorityJsonOrFile) {
 }
 
 authority parse_json_authority_or_key(const std::string& authorityJsonOrFile) {
-   if (boost::istarts_with(authorityJsonOrFile, "EOS") || boost::istarts_with(authorityJsonOrFile, "PUB_R1")) {
+   if (boost::istarts_with(authorityJsonOrFile, "TLOS") || boost::istarts_with(authorityJsonOrFile, "PUB_R1")) {
       try {
          return authority(public_key_type(authorityJsonOrFile));
       } EOS_RETHROW_EXCEPTIONS(public_key_type_exception, "Invalid public key: ${public_key}", ("public_key", authorityJsonOrFile))


### PR DESCRIPTION
This should fix https://github.com/Telos-Foundation/telos/issues/50