### PR TITLE
Fix for total producer vote weight

### DIFF
--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -330,6 +330,7 @@
         {"name":"proxy",                "type":"account_name"},
         {"name":"producers",            "type":"account_name[]"},
         {"name":"staked",               "type":"int64"},
+        {"name":"last_stake",           "type":"int64"},
         {"name":"last_vote_weight",     "type":"float64"},
         {"name":"proxied_vote_weight",  "type":"float64"},
         {"name":"is_proxy",             "type":"bool"}

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -102,6 +102,7 @@ namespace eosiosystem {
       account_name                proxy = 0; /// the proxy set by the voter, if any
       std::vector<account_name>   producers; /// the producers approved by this voter if no proxy set
       int64_t                     staked = 0;
+      int64_t                 last_stake = 0;
 
       /**
        *  Every time a vote is cast we must first "undo" the last vote weight, before casting the
@@ -125,7 +126,7 @@ namespace eosiosystem {
       uint64_t primary_key()const { return owner; }
 
       // explicit serialization macro is not necessary, used here only to improve compilation time
-      EOSLIB_SERIALIZE( voter_info, (owner)(proxy)(producers)(staked)(last_vote_weight)(proxied_vote_weight)(is_proxy)(reserved1)(reserved2)(reserved3) )
+      EOSLIB_SERIALIZE( voter_info, (owner)(proxy)(producers)(staked)(last_stake)(last_vote_weight)(proxied_vote_weight)(is_proxy)(reserved1)(reserved2)(reserved3) )
    };
 
    typedef eosio::multi_index< N(voters), voter_info>  voters_table;
@@ -237,6 +238,8 @@ namespace eosiosystem {
         
       private:
          
+         void recalculate_votes();
+
          void updateRotationTime(block_timestamp block_time);
 
          void setBPsRotation(account_name bpOut, account_name sbpIn);

--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -107,24 +107,25 @@ void system_contract::recalculate_votes(){
         _gstate.total_producer_vote_weight = 0;
         _gstate.total_activated_stake = 0;
         boost::container::flat_map<account_name, bool> processed_proxies;
-        for(const auto &voter : _voters){
-            if(voter.proxy && !processed_proxies[voter.proxy]){
-                auto proxy = _voters.find(voter.proxy);
+        for (auto voter = _voters.begin(); voter != _voters.end(); ++voter) {
+            if(voter->proxy && !processed_proxies[voter->proxy]){
+                auto proxy = _voters.find(voter->proxy);
                 _voters.modify( proxy, 0, [&]( auto& av ) {
                     av.last_vote_weight = 0;
                     av.last_stake = 0;
                     av.proxied_vote_weight = 0;
                 });
-                processed_proxies[voter.proxy] = true;
+                processed_proxies[voter->proxy] = true;
             }
-            if(!voter.is_proxy || !processed_proxies[voter.owner]){
+            if(!voter->is_proxy || !processed_proxies[voter->owner]){
                 _voters.modify( voter, 0, [&]( auto& av ) {
                     av.last_vote_weight = 0;
                     av.last_stake = 0;
                     av.proxied_vote_weight = 0;
                 });
+                processed_proxies[voter->owner] = true;
             }
-            update_votes(voter.owner, voter.proxy, voter.producers, true);
+            update_votes(voter->owner, voter->proxy, voter->producers, true);
         }
     }
 }

--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -46,6 +46,16 @@ void system_contract::onblock(block_timestamp timestamp, account_name producer)
         print("\nonblock: network isn't activated");
         return;
     }
+
+    // iterate and fix the total_producer_vote_weight = _producers(sum) if < 0 
+    // for the current issue on the testnet : this should be removed once the fix is applied
+    if (_gstate.total_producer_vote_weight <= -0.1){ // -0.1 threshold for floating point calc ?
+        print("\n Negative total_weight_vote fix applied !");
+        _gstate.total_producer_vote_weight = 0;
+        for (const auto &prod : _producers) {
+            _gstate.total_producer_vote_weight += prod.total_votes;
+        }
+    }
         
     if (_gstate.last_pervote_bucket_fill == 0) /// start the presses
         _gstate.last_pervote_bucket_fill = current_time();

--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -106,6 +106,11 @@ void system_contract::recalculate_votes(){
     if (_gstate.total_producer_vote_weight <= -0.1){ // -0.1 threshold for floating point calc ?
         _gstate.total_producer_vote_weight = 0;
         _gstate.total_activated_stake = 0;
+        for(auto producer = _producers.begin(); producer != _producers.end(); ++producer){
+            _producers.modify(producer, 0, [&](auto &p) {
+                p.total_votes = 0;
+            });
+        }
         boost::container::flat_map<account_name, bool> processed_proxies;
         for (auto voter = _voters.begin(); voter != _voters.end(); ++voter) {
             if(voter->proxy && !processed_proxies[voter->proxy]){

--- a/contracts/eosio.system/voting.cpp
+++ b/contracts/eosio.system/voting.cpp
@@ -252,15 +252,15 @@ namespace eosiosystem {
        if(prod.active()) { 
          totalProducers++;
        }
+
+       // 30 max producers allowed to vote
+       if(totalProducers >= 30){
+         break;
+       }
      }
 
      if(totalProducers == 0){
         return 0;
-     }
-
-     // 30 max producers allowed to vote
-     if(totalProducers > 30) {
-       totalProducers = 30;
      }
 
      double k = 1 - VOTE_VARIATION;
@@ -322,56 +322,49 @@ namespace eosiosystem {
          totalStaked += voter->proxied_vote_weight;
       }
 
-      auto inverse_stake = inverseVoteWeight((double )totalStaked, (double) producers.size());
-      auto new_vote_weight = inverse_stake;
-
-      /**
-       * The first time someone votes we calculate and set last_vote_weight, since they cannot unstake until
-       * after total_activated_stake hits threshold, we can use last_vote_weight to determine that this is
-       * their first vote and should consider their stake activated.
-       * 
-       * Setting a proxy will change the global staked if the proxied producer has voted. 
-       */
-      if( voter->last_vote_weight <= 0.0 && producers.size() > 0 && voting ) {
-          _gstate.total_activated_stake += voter->staked;
-          
-          if(voter->proxied_vote_weight > 0) {
-           _gstate.total_activated_stake += voter->proxied_vote_weight;
-          }
-
-          checkNetworkActivation();
-      } else if(voter->last_vote_weight <= 0.0 && proxy && voting) {
-        auto prx = _voters.find(proxy);
-        if(prx != _voters.end() && prx->last_vote_weight > 0){
-          _gstate.total_activated_stake += voter->staked;
-
-          checkNetworkActivation();
-        }
-      } else if(producers.size() == 0 && !proxy && voting ) {
-         _gstate.total_activated_stake -= voter->staked;
-
-         if(voter->proxied_vote_weight > 0) {
-           _gstate.total_activated_stake -= voter->proxied_vote_weight;
-         }
+      // when unvoting, set the stake used for calculations to 0
+      // since it is the equivalent to retracting your stake
+      if(voting && !proxy && producers.size() == 0){
+         totalStaked = 0;
       }
 
+      // when a voter or a proxy votes or changes stake, the total_activated stake should be re-calculated
+      // any proxy stake handling should be done when the proxy votes or on weight propagation
+      // if(_gstate.thresh_activated_stake_time == 0 && !proxy && !voter->proxy){
+      if(!proxy && !voter->proxy){
+         _gstate.total_activated_stake += totalStaked - voter->last_stake;
+         checkNetworkActivation();
+      }
+
+      auto new_vote_weight = inverseVoteWeight((double )totalStaked, (double) producers.size());
       boost::container::flat_map<account_name, pair<double, bool /*new*/> > producer_deltas;
 
+      // print("\n Voter : ", voter->last_stake, " = ", voter->last_vote_weight, " = ", proxy, " = ", producers.size(), " = ", totalStaked, " = ", new_vote_weight);
+      
       //Voter from second vote
-      if ( voter->last_vote_weight > 0 ) {
-        print("\n from second vote");
-           
-         //if voter account has set proxy to a other voter account
+      if ( voter->last_stake > 0 ) {
+
+         //if voter account has set proxy to another voter account
          if( voter->proxy ) { 
             auto old_proxy = _voters.find( voter->proxy );
 
             eosio_assert( old_proxy != _voters.end(), "old proxy not found" ); //data corruption
+               
             _voters.modify( old_proxy, 0, [&]( auto& vp ) {
-                  vp.proxied_vote_weight -= voter->last_vote_weight;
-               });
-            propagate_weight_change( *old_proxy );
-         } 
-         else {
+               vp.proxied_vote_weight -= voter->last_stake;
+            });
+
+            // propagate weight here only when switching proxies
+            // otherwise propagate happens in the case below
+            if( proxy != voter->proxy ){ 
+               // if(_gstate.thresh_activated_stake_time == 0){
+                  _gstate.total_activated_stake += totalStaked - voter->last_stake;
+                  checkNetworkActivation();
+               // }
+
+               propagate_weight_change( *old_proxy );
+            }
+         } else {
             for( const auto& p : voter->producers ) {
                auto& d = producer_deltas[p];
                d.first -= voter->last_vote_weight;
@@ -385,50 +378,26 @@ namespace eosiosystem {
          eosio_assert( new_proxy != _voters.end(), "invalid proxy specified" ); //if ( !voting ) { data corruption } else { wrong vote }
          eosio_assert( !voting || new_proxy->is_proxy, "proxy not found" );
         
-        if( voting ) {
          _voters.modify( new_proxy, 0, [&]( auto& vp ) {
-              vp.proxied_vote_weight += voter->staked;
-            });
-         } else {
-            _voters.modify( new_proxy, 0, [&]( auto& vp ) {
-              vp.proxied_vote_weight = voter->staked;
-          });
-        }
+            vp.proxied_vote_weight += voter->staked;
+         });
          
-        if((*new_proxy).last_vote_weight > 0){
+         if((*new_proxy).last_vote_weight > 0){
+            // if(_gstate.thresh_activated_stake_time == 0){
+               _gstate.total_activated_stake += totalStaked - voter->last_stake;
+               checkNetworkActivation();
+            // }
+            
             propagate_weight_change( *new_proxy );
-        }
+         }
       } else {
          if( new_vote_weight >= 0 ) {
-           //if voter is proxied
-           //remove staked provided to account and propagate new vote weight
-            if(voter->proxy){
-             auto old_proxy = _voters.find( voter->proxy );
-              eosio_assert( old_proxy != _voters.end(), "old proxy not found" ); //data corruption
-              _voters.modify( old_proxy, 0, [&]( auto& vp ) {
-                  vp.proxied_vote_weight -= voter->staked;
-               });
-              propagate_weight_change( *old_proxy );
+            for( const auto& p : producers ) {
+               auto& d = producer_deltas[p]; 
+               d.first += new_vote_weight;
+               d.second = true;
             }
-            if( voting ) {
-              for( const auto& p : producers ) {
-                auto& d = producer_deltas[p]; 
-                d.first += new_vote_weight;
-                d.second = true;
-              }
-            } else { //delegate bandwidth
-              if(voter->last_vote_weight > 0){
-                propagate_weight_change(*voter);
-              }
-            }
-         } 
-         //else { // this is handled automatically with the producer delta below
-        //    //if voter is unvoting, global total_producer_vote_weight should be updated
-        //    _gstate.total_producer_vote_weight -= voter->last_vote_weight;
-        //    if(_gstate.total_producer_vote_weight < 0){
-        //      _gstate.total_producer_vote_weight = 0;
-        //    }
-        //  }
+         }
       }
 
       for( const auto& pd : producer_deltas ) {
@@ -441,7 +410,6 @@ namespace eosiosystem {
                   p.total_votes = 0;
                }
                _gstate.total_producer_vote_weight += pd.second.first;
-               //eosio_assert( p.total_votes >= 0, "something bad happened" );
             });
          } else {
             eosio_assert( !pd.second.second /* not from new set */, "producer is not registered" ); //data corruption
@@ -450,6 +418,7 @@ namespace eosiosystem {
 
       _voters.modify( voter, 0, [&]( auto& av ) {
          av.last_vote_weight = new_vote_weight;
+         av.last_stake = totalStaked;
          av.producers = producers;
          av.proxy     = proxy;
       });
@@ -482,31 +451,41 @@ namespace eosiosystem {
       }
    }
 
+
    void system_contract::propagate_weight_change(const voter_info &voter) {
-     eosio_assert( voter.proxy == 0 || !voter.is_proxy, "account registered as a proxy is not allowed to use a proxy");
-     
-     auto totalStake = double(voter.staked);
-     if(voter.is_proxy){
-        totalStake += voter.proxied_vote_weight;
-     } 
-     double new_weight = inverseVoteWeight(totalStake, voter.producers.size());
+      eosio_assert( voter.proxy == 0 || !voter.is_proxy, "account registered as a proxy is not allowed to use a proxy");
+      
+      auto totalStake = double(voter.staked);
+      if(voter.is_proxy){
+         totalStake += voter.proxied_vote_weight;
+      } 
+      double new_weight = inverseVoteWeight(totalStake, voter.producers.size());
     
-     if (voter.proxy) {
-       auto &proxy = _voters.get(voter.proxy, "proxy not found"); // data corruption
-       _voters.modify(proxy, 0, [&](auto &p) { p.proxied_vote_weight = proxy.staked; });
-       
-       propagate_weight_change(proxy);
-     } else {
-       for (auto acnt : voter.producers) {
-         auto &pitr = _producers.get(acnt, "producer not found"); // data corruption
-         _producers.modify(pitr, 0, [&](auto &p) {
-           p.total_votes += new_weight;
-           _gstate.total_producer_vote_weight += new_weight;
-         });
-       }
-     }
-     _voters.modify(voter, 0, [&](auto &v) { 
-        v.last_vote_weight = new_weight; 
+      if (new_weight - voter.last_vote_weight > 1){
+         if (voter.proxy) {
+            if(voter.last_stake != totalStake){
+               // this part should never happen since the function is called only on proxies
+               auto &proxy = _voters.get(voter.proxy, "proxy not found"); // data corruption
+               _voters.modify(proxy, 0, [&](auto &p) { 
+                  p.proxied_vote_weight += totalStake - voter.last_stake;
+               });
+               
+               propagate_weight_change(proxy);
+            }
+         } else {
+            for (auto acnt : voter.producers) {
+               auto &pitr = _producers.get(acnt, "producer not found"); // data corruption
+               _producers.modify(pitr, 0, [&](auto &p) {
+                  p.total_votes += new_weight;
+                  _gstate.total_producer_vote_weight += new_weight;
+               });
+            }
+         }
+      }
+      
+      _voters.modify(voter, 0, [&](auto &v) { 
+         v.last_vote_weight = new_weight; 
+         v.last_stake = totalStake;
       });
    }
 

--- a/contracts/eosio.system/voting.cpp
+++ b/contracts/eosio.system/voting.cpp
@@ -342,8 +342,9 @@ namespace eosiosystem {
           checkNetworkActivation();
       } else if(voter->last_vote_weight <= 0.0 && proxy && voting) {
         auto prx = _voters.find(proxy);
-        if(prx->last_vote_weight > 0){
+        if(prx != _voters.end() && prx->last_vote_weight > 0){
           _gstate.total_activated_stake += voter->staked;
+
           checkNetworkActivation();
         }
       } else if(producers.size() == 0 && !proxy && voting ) {
@@ -358,6 +359,7 @@ namespace eosiosystem {
 
       //Voter from second vote
       if ( voter->last_vote_weight > 0 ) {
+        print("\n from second vote");
            
          //if voter account has set proxy to a other voter account
          if( voter->proxy ) { 
@@ -419,15 +421,16 @@ namespace eosiosystem {
                 propagate_weight_change(*voter);
               }
             }
-         } else {
-           //if voter is unvoting, global total_producer_vote_weight should be updated
-           _gstate.total_producer_vote_weight -= voter->last_vote_weight;
-           if(_gstate.total_producer_vote_weight < 0){
-             _gstate.total_producer_vote_weight = 0;
-           }
-         }
-      } 
-      
+         } 
+         //else { // this is handled automatically with the producer delta below
+        //    //if voter is unvoting, global total_producer_vote_weight should be updated
+        //    _gstate.total_producer_vote_weight -= voter->last_vote_weight;
+        //    if(_gstate.total_producer_vote_weight < 0){
+        //      _gstate.total_producer_vote_weight = 0;
+        //    }
+        //  }
+      }
+
       for( const auto& pd : producer_deltas ) {
          auto pitr = _producers.find( pd.first );
          if( pitr != _producers.end() ) {
@@ -498,6 +501,7 @@ namespace eosiosystem {
          auto &pitr = _producers.get(acnt, "producer not found"); // data corruption
          _producers.modify(pitr, 0, [&](auto &p) {
            p.total_votes += new_weight;
+           _gstate.total_producer_vote_weight += new_weight;
          });
        }
      }


### PR DESCRIPTION
This contains the fix for correctly calculating the total_producer_vote_weight. There is also a patch in proudcer_pay, supposed to run onblock to fix the current situation of the testnet. It will run only when the total weight is a relevant negative. (theoretically only once, since the fix will keep the vote from going negative) (this should be removed at a later time, after the situation is fixed).

Along with this, there is the addition of a small fix to check the chosen proxy actually exists and is not a bogus name.