### PR TITLE
Automated claimrewards

### DIFF
--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -15,7 +15,8 @@ namespace eosiosystem {
     _producers(_self,_self),
     _global(_self,_self),
     _rotations(_self,_self),
-    _rammarket(_self,_self)
+    _rammarket(_self,_self),
+    payments(_self, _self)
    {
       //print( "construct system\n" );
       _gstate = _global.exists() ? _global.get() : get_default_parameters();

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -52,14 +52,15 @@ namespace eosiosystem {
       uint16_t             last_producer_schedule_size = 0;
       double               total_producer_vote_weight = 0; /// the sum of all producer votes
       block_timestamp      last_name_close;
-      uint32_t             last_claimrewards;
+      uint32_t             last_claimrewards = 0;
+      uint32_t             next_payment = 0;
 
       // explicit serialization macro is not necessary, used here only to improve compilation time
       EOSLIB_SERIALIZE_DERIVED( eosio_global_state, eosio::blockchain_parameters,
                                 (max_ram_size)(total_ram_bytes_reserved)(total_ram_stake)
                                 (last_producer_schedule_update)(last_pervote_bucket_fill)
                                 (pervote_bucket)(perblock_bucket)(total_unpaid_blocks)(total_activated_stake)(thresh_activated_stake_time)
-                                (last_producer_schedule_size)(total_producer_vote_weight)(last_name_close) )
+                                (last_producer_schedule_size)(total_producer_vote_weight)(last_name_close)(last_claimrewards)(next_payment) )
    };
 
    /**
@@ -170,6 +171,7 @@ namespace eosiosystem {
          eosio_global_state     _gstate;
          rotation_info          _grotations;
          rammarket              _rammarket;
+         payments_table         payments;
 
       public:
          system_contract( account_name s );

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -52,6 +52,7 @@ namespace eosiosystem {
       uint16_t             last_producer_schedule_size = 0;
       double               total_producer_vote_weight = 0; /// the sum of all producer votes
       block_timestamp      last_name_close;
+      uint32_t             last_claimrewards;
 
       // explicit serialization macro is not necessary, used here only to improve compilation time
       EOSLIB_SERIALIZE_DERIVED( eosio_global_state, eosio::blockchain_parameters,
@@ -64,8 +65,7 @@ namespace eosiosystem {
    /**
     * TELOS CHANGES:
     * 
-    * 1. Added missed_blocks field, used for counting missed blocks and
-    *    adjusting producer payout accordingly.
+    * 1. Added missed_blocks field, used for counting missed blocks.
     */
    struct producer_info {
       account_name          owner;
@@ -134,6 +134,17 @@ namespace eosiosystem {
       // explicit serialization macro is not necessary, used here only to improve compilation time
       EOSLIB_SERIALIZE( voter_info, (owner)(proxy)(producers)(staked)(last_stake)(last_vote_weight)(proxied_vote_weight)(is_proxy)(reserved1)(reserved2)(reserved3) )
    };
+
+   //tracks automated claimreward payments
+   struct payment {
+     account_name bp;
+     asset pay;
+
+     uint64_t primary_key() const { return bp; }
+     EOSLIB_SERIALIZE(payment, (bp)(pay))
+   };
+
+   typedef eosio::multi_index<N(payments), payment> payments_table;
 
    typedef eosio::multi_index< N(voters), voter_info>  voters_table;
 

--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -229,7 +229,7 @@ void system_contract::onblock(block_timestamp timestamp, account_name producer) 
 
         payments.erase(p);
 
-        _gstate.next_payment = (timestamp.slot + uint32_t(300)); //300 blocks in 5 minutes
+        _gstate.next_payment = (timestamp.slot + uint32_t(600)); //600 blocks in 5 minutes
     }
 }
 


### PR DESCRIPTION
Implemented solution for issue #61 

- Claimrewards is automatically called at an arbitrary time once per day (every 172800 blocks) by whichever BP happens to be producing at that time.

- At the time of the daily claimrewards call, a snapshot of all BP's and Standby's is made. Rewards are calculated for all **active** bps/standbys and saved in the payments table.

- Every 5 minutes (600 blocks), the current producer looks at the first entry in the payments table and sends the payment to the intended recipient. This method should exhaust all pending payments within 5 hours. If no more entries exist, no payments are made until the next snapshot the following day.