### PR TITLE
Ratify/Amend Contract

### DIFF
--- a/contracts/ratify.amend/ratify.amend.hpp
+++ b/contracts/ratify.amend/ratify.amend.hpp
@@ -32,7 +32,7 @@ class ratifyamend : public contract {
          * Creates a new document and inserts it into the documents table.
          * @param title - string representation of document title
          * @param clauses - vector of strings representing ipfs urls to the text of each clause
-        */
+         */
         void insertdoc(string title, vector<string> clauses);
 
         /**
@@ -42,32 +42,39 @@ class ratifyamend : public contract {
          * @param document_id - id of document being edited
          * @param clause_id - id of clause in document to overwrite
          * @param proposer - account name submitting proposal
-        */
+         */
         void propose(string title, string ipfs_url, uint64_t document_id, uint64_t clause_id, account_name proposer);
 
         /**
          * Casts a vote in a certain direction on a proposal, by the weight of the voter's tlos tokens.
          * @param proposal_id - id of proposal to vote on
          * @param vote - direction of vote (0 = NO, 1 = YES, 2 = ABSTAIN)
-        */
+         */
         void vote(uint64_t proposal_id, uint16_t vote, account_name voter);
 
         /**
          * Removes a vote from the proposal matching the given proposal id.
          * @param proposal_id - id of proposal from which to rescinf vote
          * @param voter - account name that cast vote being removed
-        */
+         */
         void unvote(uint64_t proposal_id, account_name voter);
 
         /**
          * Closes a proposal and declares a PASS or FAIL if its past its expiration, and not already closed.
          * @param proposal_id - proposal to close
-        */
+         */
         void close(uint64_t proposal_id);
+
+        /**
+         * Force closes a proposal a certain time after expiration. Forfeits refund.
+         */
+        //void forceclose(uint64_t proposal_id);
 
     protected:
 
         void update_thresh();
+
+        void update_doc(uint64_t document_id, uint64_t clause_id, string new_clause);
 
         /// @abi table documents i64
         struct document {

--- a/contracts/ratify.amend/ratify.amend.hpp
+++ b/contracts/ratify.amend/ratify.amend.hpp
@@ -43,7 +43,7 @@ class ratifyamend : public contract {
          * @param clause_id - id of clause in document to overwrite
          * @param proposer - account name submitting proposal
          */
-        void propose(string title, string ipfs_url, uint64_t document_id, uint64_t clause_id, account_name proposer);
+        void propose(string title, uint64_t document_id, vector<uint16_t> new_clause_ids, vector<string> new_ipfs_urls, account_name proposer);
 
         /**
          * Casts a vote in a certain direction on a proposal, by the weight of the voter's tlos tokens.
@@ -65,16 +65,11 @@ class ratifyamend : public contract {
          */
         void close(uint64_t proposal_id);
 
-        /**
-         * Force closes a proposal a certain time after expiration. Forfeits refund.
-         */
-        //void forceclose(uint64_t proposal_id);
-
     protected:
 
         void update_thresh();
 
-        void update_doc(uint64_t document_id, uint64_t clause_id, string new_clause);
+        void update_doc(uint64_t document_id, vector<uint16_t> new_clause_ids, vector<string> new_ipfs_urls);
 
         /// @abi table documents i64
         struct document {
@@ -90,9 +85,9 @@ class ratifyamend : public contract {
         struct proposal {
             uint64_t id;
             uint64_t document_id;
-            uint64_t clause_id;
             string title;
-            string ipfs_url;
+            vector<uint16_t> new_clause_ids;
+            vector<string> new_ipfs_urls;
             uint64_t yes_count;
             uint64_t no_count;
             uint64_t abstain_count;
@@ -101,7 +96,7 @@ class ratifyamend : public contract {
             uint64_t status; // 0 = OPEN, 1 = PASSED, 2 = FAILED
 
             uint64_t primary_key() const { return id; }
-            EOSLIB_SERIALIZE(proposal, (id)(document_id)(clause_id)(title)(ipfs_url)(yes_count)(no_count)(abstain_count)(proposer)(expiration)(status))
+            EOSLIB_SERIALIZE(proposal, (id)(document_id)(title)(new_clause_ids)(new_ipfs_urls)(yes_count)(no_count)(abstain_count)(proposer)(expiration)(status))
         };
 
         /// @abi table threshold

--- a/contracts/trail.service/trail.connections/trailconn.voting.hpp
+++ b/contracts/trail.service/trail.connections/trailconn.voting.hpp
@@ -1,3 +1,11 @@
+/**
+ * This file includes all definitions necessary to interact with Trail's voting system. Developers who want to
+ * utilize the system simply must include this file in their implementation to interact with the information
+ * stores by Trail.
+ * 
+ * @author Craig Branscom
+ */
+
 #include <eosiolib/eosio.hpp>
 #include <eosiolib/permission.hpp>
 #include <eosiolib/asset.hpp>
@@ -71,16 +79,17 @@ typedef eosio::multi_index<N(accounts), account> accounts;
 
 /**
  * Updates the voter's tlos_weight on their VoterID.
+ * @param voter - account from which to retrieve liquid TLOS amount
 */
 int64_t get_liquid_tlos(account_name voter) {
     accounts accountstable(N(eosio.token), voter);
-    auto a = accountstable.find(asset(int64_t(0), S(4, TLOS)).symbol.name()); //find better way to get key?
+    auto a = accountstable.find(asset(int64_t(0), S(4, TLOS)).symbol.name()); //TODO: find better way to get TLOS symbol?
 
     int64_t liquid_tlos = 0;
 
     if (a != accountstable.end()) {
         auto acct = *a;
-        liquid_tlos = acct.balance.amount;
+        liquid_tlos = acct.balance.amount / int64_t(10000); //divide to get actual balance
     }
     
     return liquid_tlos;

--- a/contracts/trail.service/trail.service.cpp
+++ b/contracts/trail.service/trail.service.cpp
@@ -93,8 +93,8 @@ void trail::unregvoter(account_name voter) {
 }
 
 void trail::addreceipt(uint64_t vote_code, uint64_t vote_scope, uint64_t vote_key, uint16_t direction, account_name voter) {
-    //NOTE: Maybe require_auth2? Add param or voting_contract? contract would send _self. So voting_contract@eosio.code? Call should only come from votereceipt contract
-    //require_auth(voter);
+    //NOTE: Maybe require_auth2? Call should only come from voting contract
+    require_auth(vote_code);
 
     voters_table voters(_self, voter);
     auto v = voters.find(voter);
@@ -116,7 +116,6 @@ void trail::addreceipt(uint64_t vote_code, uint64_t vote_scope, uint64_t vote_ke
 
     //search for existing receipt
     for (votereceipt r : vid.receipt_list) {
-
         if (r.vote_code == vote_code && r.vote_scope == vote_scope && r.vote_key == vote_key) {
             print("\nExisting receipt found. Updating...");
 
@@ -125,30 +124,20 @@ void trail::addreceipt(uint64_t vote_code, uint64_t vote_scope, uint64_t vote_ke
 
             break;
         }
-
         itr++;
     }
 
     if (itr == vid.receipt_list.end()) {
-
         vid.receipt_list.push_back(new_vr);
+    } 
 
-        voters.modify(v, 0, [&]( auto& a ) {
-            a.receipt_list = vid.receipt_list;
-        });
-    } else {
-
-        voters.modify(v, 0, [&]( auto& a ) {
-            a.receipt_list = vid.receipt_list;
-        });
-    }
+    voters.modify(v, 0, [&]( auto& a ) {
+        a.receipt_list = vid.receipt_list;
+    });
 
     print("\nVoteReceipt Addition: SUCCESS");
 }
 
-/**
- * Removes an existing vote receipt from a VoterID.
-*/
 void trail::rmvreceipt(uint64_t vote_code, uint64_t vote_scope, uint64_t vote_key, account_name voter) {
     //NOTE: Maybe require_auth2? Add param or voting_contract? contract would send _self. So voting_contract@eosio.code? Call should only come from votereceipt contract
     //require_auth(voter);

--- a/contracts/trail.service/trail.service.cpp
+++ b/contracts/trail.service/trail.service.cpp
@@ -139,8 +139,7 @@ void trail::addreceipt(uint64_t vote_code, uint64_t vote_scope, uint64_t vote_ke
 }
 
 void trail::rmvreceipt(uint64_t vote_code, uint64_t vote_scope, uint64_t vote_key, account_name voter) {
-    //NOTE: Maybe require_auth2? Add param or voting_contract? contract would send _self. So voting_contract@eosio.code? Call should only come from votereceipt contract
-    //require_auth(voter);
+    require_auth(voter);
 
     voters_table voters(_self, voter);
     auto v = voters.find(voter);
@@ -150,12 +149,14 @@ void trail::rmvreceipt(uint64_t vote_code, uint64_t vote_scope, uint64_t vote_ke
     auto vid = *v;
 
     auto itr = vid.receipt_list.begin();
+    bool found = false;
 
     //search for existing receipt
     for (votereceipt r : vid.receipt_list) {
 
         if (r.vote_code == vote_code && r.vote_scope == vote_scope && r.vote_key == vote_key) {
             print("\nExisting receipt found. Removing...");
+            found = true;
 
             auto vr = vid.receipt_list.erase(itr);
 
@@ -165,7 +166,7 @@ void trail::rmvreceipt(uint64_t vote_code, uint64_t vote_scope, uint64_t vote_ke
         itr++;
     }
 
-    eosio_assert(itr != vid.receipt_list.end(), "Receipt not found");
+    eosio_assert(found, "Receipt not found");
 
     voters.modify(v, 0, [&]( auto& a ) {
         a.receipt_list = vid.receipt_list;

--- a/contracts/trail.service/trail.service.cpp
+++ b/contracts/trail.service/trail.service.cpp
@@ -94,7 +94,7 @@ void trail::unregvoter(account_name voter) {
 
 void trail::addreceipt(uint64_t vote_code, uint64_t vote_scope, uint64_t vote_key, uint16_t direction, account_name voter) {
     //NOTE: Maybe require_auth2? Call should only come from voting contract
-    require_auth(vote_code);
+    require_auth(voter);
 
     voters_table voters(_self, voter);
     auto v = voters.find(voter);

--- a/contracts/trail.service/trail.service.hpp
+++ b/contracts/trail.service/trail.service.hpp
@@ -70,9 +70,6 @@ class trail : public contract {
 
     protected:
 
-        /**
-         * 
-        */
         /// @abi table registries i64
         struct registration {
             asset native;
@@ -82,41 +79,8 @@ class trail : public contract {
             uint64_t by_publisher() const { return publisher; }
         };
 
-        /*
-        struct voteinfo { //TODO: change to votereceipt?
-            uint64_t vote_code; // code of contract receiving vote //TODO: change to account_name?
-            uint64_t vote_scope; // scope of contract receiving vote
-            uint64_t vote_key; // key to retrieve voted object in external contract
-            uint16_t direction; // 0 = abstain, 1 = yes, 2 = no TODO: use enum? 
-            uint64_t weight; // weight of votes applied
-        };
-
-        /// @abi table voters i64
-        struct voterid {
-            account_name voter;
-            vector<voteinfo> votes_list;
-            uint64_t tlos_weight;
-
-            uint64_t primary_key() const { return voter; }
-            EOSLIB_SERIALIZE(voterid, (voter)(votes_list)(tlos_weight))
-        };
-
-        /// @abi table environment
-        struct environment {
-            account_name publisher;
-
-            uint64_t total_tokens;
-            uint64_t total_voters;
-
-            uint64_t primary_key() const { return publisher; }
-            EOSLIB_SERIALIZE(environment, (publisher)(total_tokens)(total_voters))
-        };
-        */
-
         typedef multi_index<N(registries), registration> registries_table;
-        //typedef multi_index<N(voters), voterid> voters_table;
 
-        //typedef singleton<N(environment), environment> environment_singleton;
         environment_singleton env_singleton;
         environment env_struct;
 };


### PR DESCRIPTION
Resolves issue #29.

- Contract publisher can create new documents, which comprise of a title and a sequence of 1 or more clauses (saved as the ipfs hash of the clauses' text).

- Users register their account name with trailservice through the regvoter() action. This issues the account a VoterID which records information about all votes cast.

- Users propose ratifications or amendments for particular clauses on a given document, which are then voted on by all registered voters. Proposals will expire after a certain amount of time, and can be closed by anyone calling the close() action and passing in the appropriate proposal_id.

- All registered voters can then vote the weight of their liquid TLOS towards any open proposal. Revoting will overwrite your account's previous votes, and calling unvote() will remove the vote entirely. Users can vote either `yes`, `no`, `abstain`. Voting yes and no have obvious effects, however casting an abstain vote means a user doesn't choose a side, but still wants their vote to count towards the quorum. Unvoting removes the vote from the quorum.