### PR TITLE
Feature/deactivate contract features

### DIFF
--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -22,15 +22,15 @@
       "name": "rotation_info",
       "base": "",
       "fields": [
-        {"name":"is_rotation_active",      "type":"bool"},
-        {"name":"bp_currently_out",     "type":"account_name"},
-        {"name":"sbp_currently_in",     "type":"account_name"},
-        {"name":"bp_out_index",         "type":"uint32"},
-        {"name":"sbp_in_index",         "type":"uint32"},
-        {"name":"next_rotation_time",   "type":"block_timestamp_type"},
-        {"name":"last_rotation_time",   "type":"block_timestamp_type"},
-        {"name":"is_kick_active",   "type":"bool"},
-        {"name":"current_bp",                 "type":"account_name"},
+        {"name":"is_rotation_active",         "type":"bool"},
+        {"name":"bp_currently_out",           "type":"account_name"},
+        {"name":"sbp_currently_in",           "type":"account_name"},
+        {"name":"bp_out_index",               "type":"uint32"},
+        {"name":"sbp_in_index",               "type":"uint32"},
+        {"name":"next_rotation_time",         "type":"block_timestamp_type"},
+        {"name":"last_rotation_time",         "type":"block_timestamp_type"},
+        {"name":"is_kick_active",             "type":"bool"},
+        {"name":"last_onblock_caller",        "type":"account_name"},
         {"name":"last_time_block_produced",   "type":"block_timestamp_type"}
       ]
     },{

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -470,6 +470,14 @@
      "type": "canceldelay",
      "ricardian_contract": ""
    },{
+     "name": "setkick",
+     "type": "setkick",
+     "ricardian_contract": ""
+   },{
+     "name": "setrotate",
+     "type": "setrotate",
+     "ricardian_contract": ""
+   },{
      "name": "onerror",
      "type": "onerror",
      "ricardian_contract": ""

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -22,14 +22,14 @@
       "name": "rotation_info",
       "base": "",
       "fields": [
-        {"name":"is_kick_active",      "type":"bool"},
+        {"name":"is_rotation_active",      "type":"bool"},
         {"name":"bp_currently_out",     "type":"account_name"},
         {"name":"sbp_currently_in",     "type":"account_name"},
         {"name":"bp_out_index",         "type":"uint32"},
         {"name":"sbp_in_index",         "type":"uint32"},
         {"name":"next_rotation_time",   "type":"block_timestamp_type"},
         {"name":"last_rotation_time",   "type":"block_timestamp_type"},
-        {"name":"is_rotation_active",   "type":"bool"},
+        {"name":"is_kick_active",   "type":"bool"},
         {"name":"current_bp",                 "type":"account_name"},
         {"name":"last_time_block_produced",   "type":"block_timestamp_type"}
       ]

--- a/contracts/eosio.system/eosio.system.abi
+++ b/contracts/eosio.system/eosio.system.abi
@@ -22,12 +22,14 @@
       "name": "rotation_info",
       "base": "",
       "fields": [
+        {"name":"is_kick_active",      "type":"bool"},
         {"name":"bp_currently_out",     "type":"account_name"},
         {"name":"sbp_currently_in",     "type":"account_name"},
         {"name":"bp_out_index",         "type":"uint32"},
         {"name":"sbp_in_index",         "type":"uint32"},
         {"name":"next_rotation_time",   "type":"block_timestamp_type"},
         {"name":"last_rotation_time",   "type":"block_timestamp_type"},
+        {"name":"is_rotation_active",   "type":"bool"},
         {"name":"current_bp",                 "type":"account_name"},
         {"name":"last_time_block_produced",   "type":"block_timestamp_type"}
       ]
@@ -59,6 +61,18 @@
       "fields": [
         {"name":"permission", "type":"permission_level"},
         {"name":"weight",     "type":"weight_type"}
+      ]
+    },{
+      "name": "setkick",
+      "base": "",
+      "fields": [
+        {"name":"state", "type":"bool"}
+      ]
+    },{
+      "name": "setrotate",
+      "base": "",
+      "fields": [
+        {"name":"state", "type":"bool"}
       ]
     },{
       "name": "wait_weight",

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -104,6 +104,7 @@ namespace eosiosystem {
    }
 
    void system_contract::setkick( bool state ) {
+      eosio_assert(false, "This action isn't implemented currently");
       require_auth( _self );
       _grotations.is_kick_active = state;
    }

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -47,7 +47,6 @@ namespace eosiosystem {
       return dp;
    }
 
-
    system_contract::~system_contract() {
       //print( "destruct system\n" );
       _global.set( _gstate, _self );

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -20,7 +20,7 @@ namespace eosiosystem {
       //print( "construct system\n" );
       _gstate = _global.exists() ? _global.get() : get_default_parameters();
       _grotations = _rotations.get_or_create(_self, rotation_info{
-        0, 0, 21, 75, block_timestamp(), block_timestamp(), 0, block_timestamp()
+        true, 0, 0, 21, 75, block_timestamp(), block_timestamp(), true, 0, block_timestamp()
       });
       auto itr = _rammarket.find(S(4,RAMCORE));
 
@@ -96,6 +96,14 @@ namespace eosiosystem {
       _producers.modify( prod, 0, [&](auto& p) {
             p.deactivate();
          });
+   }
+
+   void system_contract::setrotate(bool state) {
+      _grotations.is_rotation_active = state;
+   }
+
+   void system_contract::setkick(bool state) {
+      _grotations.is_kick_active = state;
    }
 
    void system_contract::bidname( account_name bidder, account_name newname, asset bid ) {
@@ -192,7 +200,7 @@ EOSIO_ABI( eosiosystem::system_contract,
      // native.hpp (newaccount definition is actually in eosio.system.cpp)
      (newaccount)(updateauth)(deleteauth)(linkauth)(unlinkauth)(canceldelay)(onerror)
      // eosio.system.cpp
-     (setram)(setparams)(setpriv)(rmvproducer)(bidname)
+     (setram)(setparams)(setpriv)(rmvproducer)(bidname)(setkick)(setrotate)
      // delegate_bandwidth.cpp
      (buyrambytes)(buyram)(sellram)(delegatebw)(undelegatebw)(refund)
      // voting.cpp

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -99,12 +99,12 @@ namespace eosiosystem {
    }
 
    void system_contract::setrotate( bool state ) {
+      eosio_assert(false, "This action isn't implemented currently");
       require_auth( _self );
       _grotations.is_rotation_active = state;
    }
 
    void system_contract::setkick( bool state ) {
-      eosio_assert(false, "This action isn't implemented currently");
       require_auth( _self );
       _grotations.is_kick_active = state;
    }

--- a/contracts/eosio.system/eosio.system.cpp
+++ b/contracts/eosio.system/eosio.system.cpp
@@ -98,11 +98,13 @@ namespace eosiosystem {
          });
    }
 
-   void system_contract::setrotate(bool state) {
+   void system_contract::setrotate( bool state ) {
+      require_auth( _self );
       _grotations.is_rotation_active = state;
    }
 
-   void system_contract::setkick(bool state) {
+   void system_contract::setkick( bool state ) {
+      require_auth( _self );
       _grotations.is_kick_active = state;
    }
 

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -90,17 +90,22 @@ namespace eosiosystem {
    };
 
    struct rotation_info {
+      bool                   is_rotation_active = true;
       account_name           bp_currently_out;
       account_name           sbp_currently_in;
       uint32_t               bp_out_index;
       uint32_t               sbp_in_index;
       block_timestamp        next_rotation_time;
       block_timestamp        last_rotation_time;
-      account_name           current_bp; 
+
+      //NOTE: This might not be the best place for this information
+
+      bool                   is_kick_active = true;
+      account_name           current_bp; //TODO: This name is ambiguous 
       block_timestamp        last_time_block_produced;
 
-      EOSLIB_SERIALIZE( rotation_info, (bp_currently_out)(sbp_currently_in)(bp_out_index)(sbp_in_index)(next_rotation_time)
-                        (last_rotation_time)(current_bp)(last_time_block_produced) )
+      EOSLIB_SERIALIZE( rotation_info, (is_rotation_active)(bp_currently_out)(sbp_currently_in)(bp_out_index)(sbp_in_index)(next_rotation_time)
+                        (last_rotation_time)(is_kick_active)(current_bp)(last_time_block_produced) )
    };
 
    struct voter_info {
@@ -239,6 +244,10 @@ namespace eosiosystem {
          void setpriv( account_name account, uint8_t ispriv );
 
          void rmvproducer( account_name producer );
+
+         void setkick(bool state);
+
+         void setrotate(bool state);
 
          void bidname( account_name bidder, account_name newname, asset bid );
         

--- a/contracts/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/eosio.system.hpp
@@ -101,11 +101,11 @@ namespace eosiosystem {
       //NOTE: This might not be the best place for this information
 
       bool                   is_kick_active = true;
-      account_name           current_bp; //TODO: This name is ambiguous 
+      account_name           last_onblock_caller; //TODO: This name is ambiguous maybe
       block_timestamp        last_time_block_produced;
 
       EOSLIB_SERIALIZE( rotation_info, (is_rotation_active)(bp_currently_out)(sbp_currently_in)(bp_out_index)(sbp_in_index)(next_rotation_time)
-                        (last_rotation_time)(is_kick_active)(current_bp)(last_time_block_produced) )
+                        (last_rotation_time)(is_kick_active)(last_onblock_caller)(last_time_block_produced) )
    };
 
    struct voter_info {

--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -43,20 +43,20 @@ const uint64_t useconds_per_year = seconds_per_year * 1000000ll;
 
 bool system_contract::crossed_missed_blocks_threshold(uint32_t amountBlocksMissed) {
     //6hrs
-    auto timeframe = (_grotations.next_rotation_time.to_time_point() - _grotations.last_rotation_time.to_time_point()).to_seconds();
+    uint64_t timeframe = std::abs((_grotations.next_rotation_time.to_time_point() - _grotations.last_rotation_time.to_time_point()).to_seconds());
    
     //get_active_producers returns the number of bytes populated
     account_name prods[21];
     uint32_t totalProds = get_active_producers(prods, sizeof(account_name) * 21) / 8;
     //Total blocks that can be produced in a cycle
-    auto maxBlocksPerCycle = (totalProds - 1) * MAX_BLOCK_PER_CYCLE;
+    uint32_t maxBlocksPerCycle = (totalProds - 1) * MAX_BLOCK_PER_CYCLE;
     //total block that can be produced in the current timeframe
-    auto totalBlocksPerTimeframe = (maxBlocksPerCycle * timeframe) / (maxBlocksPerCycle / 2);
+    uint64_t totalBlocksPerTimeframe = (maxBlocksPerCycle * timeframe) / (maxBlocksPerCycle / 2);
     //max blocks that can be produced by a single producer in a timeframe
-    auto maxBlocksPerProducer = (totalBlocksPerTimeframe * MAX_BLOCK_PER_CYCLE) / maxBlocksPerCycle;
+    uint64_t maxBlocksPerProducer = (totalBlocksPerTimeframe * MAX_BLOCK_PER_CYCLE) / maxBlocksPerCycle;
     //15% is the max allowed missed blocks per single producer
-    auto thresholdMissedBlocks = maxBlocksPerProducer * 0.15;
-
+    uint64_t thresholdMissedBlocks = uint64_t(maxBlocksPerProducer * 0.15);
+    
     return amountBlocksMissed > thresholdMissedBlocks;
 }
 
@@ -108,51 +108,51 @@ void system_contract::check_missed_blocks(block_timestamp timestamp, account_nam
     } 
     else if(producedTimeDiff > 1 && producer == _grotations.last_onblock_caller) update_producer_blocks(producer, 1, producedTimeDiff - 1);
     else {
-        auto lastPitr = _producers.find(_grotations.last_onblock_caller);
-        if (lastPitr == _producers.end()) return;
+        // auto lastPitr = _producers.find(_grotations.last_onblock_caller);
+        // if (lastPitr == _producers.end()) return;
             
-        account_name producers_schedule[21];
-        uint32_t bytes_populated = get_active_producers(producers_schedule, sizeof(account_name)*21);
+        // account_name producers_schedule[21];
+        // uint32_t bytes_populated = get_active_producers(producers_schedule, sizeof(account_name)*21);
         
-        auto currentProducerIndex = std::distance(producers_schedule, std::find(producers_schedule, producers_schedule + 21, producer));
+        // auto currentProducerIndex = std::distance(producers_schedule, std::find(producers_schedule, producers_schedule + 21, producer));
         
-        auto totalMissedSlots = std::fabs(producedTimeDiff - 1 - lastPitr->blocks_per_cycle);
+        // auto totalMissedSlots = std::fabs(producedTimeDiff - 1 - lastPitr->blocks_per_cycle);
 
-        //last producer didn't miss blocks    
-        if(totalMissedSlots == 0) {
-            //set zero to last producer blocks_per_cycle 
-            set_producer_block_produced(_grotations.last_onblock_caller, RESET_BLOCKS_PRODUCED);
+    //     //last producer didn't miss blocks    
+    //     if(totalMissedSlots == 0) {
+    //         //set zero to last producer blocks_per_cycle 
+    //         set_producer_block_produced(_grotations.last_onblock_caller, RESET_BLOCKS_PRODUCED);
 
-            update_producer_blocks(producers_schedule[currentProducerIndex - 1], RESET_BLOCKS_PRODUCED, producedTimeDiff - 1);
+    //         update_producer_blocks(producers_schedule[currentProducerIndex - 1], RESET_BLOCKS_PRODUCED, producedTimeDiff - 1);
             
-            set_producer_block_produced(producer, 1);
-        } else { //more than one producer missed blocks
-            if(totalMissedSlots / MAX_BLOCK_PER_CYCLE > 0) {
-                auto totalProdsMissedSlots = totalMissedSlots / 12;
-                auto totalCurrentProdMissedBlocks = std::fmod(totalMissedSlots, 12);
+    //         set_producer_block_produced(producer, 1);
+    //     } else { //more than one producer missed blocks
+    //         if(totalMissedSlots / MAX_BLOCK_PER_CYCLE > 0) {
+    //             auto totalProdsMissedSlots = totalMissedSlots / 12;
+    //             auto totalCurrentProdMissedBlocks = std::fmod(totalMissedSlots, 12);
                 
-                //Check if the last or the current bp missed blocks
-                if(totalCurrentProdMissedBlocks > 0) {
-                    auto lastProdTotalMissedBlocks = MAX_BLOCK_PER_CYCLE - lastPitr->blocks_per_cycle;
-                    if(lastProdTotalMissedBlocks > 0) set_producer_block_missed(producers_schedule[currentProducerIndex - 1], lastProdTotalMissedBlocks);
+    //             //Check if the last or the current bp missed blocks
+    //             if(totalCurrentProdMissedBlocks > 0) {
+    //                 auto lastProdTotalMissedBlocks = MAX_BLOCK_PER_CYCLE - lastPitr->blocks_per_cycle;
+    //                 if(lastProdTotalMissedBlocks > 0) set_producer_block_missed(producers_schedule[currentProducerIndex - 1], lastProdTotalMissedBlocks);
                     
-                    update_producer_blocks(producer, 1, totalCurrentProdMissedBlocks - lastProdTotalMissedBlocks);
-                }  else set_producer_block_produced(producer, 1);
+    //                 update_producer_blocks(producer, 1, totalCurrentProdMissedBlocks - lastProdTotalMissedBlocks);
+    //             }  else set_producer_block_produced(producer, 1);
                 
-                for(int i = 0; i <= totalProdsMissedSlots; i++) {
-                    auto lastProdIndex = currentProducerIndex - (i + 1);
-                    lastProdIndex = lastProdIndex < 0 ? 21 + lastProdIndex : lastProdIndex;
+    //             for(int i = 0; i <= totalProdsMissedSlots; i++) {
+    //                 auto lastProdIndex = currentProducerIndex - (i + 1);
+    //                 lastProdIndex = lastProdIndex < 0 ? 21 + lastProdIndex : lastProdIndex;
 
-                    auto prod = producers_schedule[lastProdIndex];
-                    set_producer_block_missed(prod, MAX_BLOCK_PER_CYCLE);                       
-                }
+    //                 auto prod = producers_schedule[lastProdIndex];
+    //                 set_producer_block_missed(prod, MAX_BLOCK_PER_CYCLE);                       
+    //             }
 
-                set_producer_block_produced(_grotations.last_onblock_caller, RESET_BLOCKS_PRODUCED);
-            } else {
-                set_producer_block_produced(_grotations.last_onblock_caller, RESET_BLOCKS_PRODUCED);
-                update_producer_blocks(producer, 1, totalMissedSlots);
-            }
-        }
+    //             set_producer_block_produced(_grotations.last_onblock_caller, RESET_BLOCKS_PRODUCED);
+    //         } else {
+    //             set_producer_block_produced(_grotations.last_onblock_caller, RESET_BLOCKS_PRODUCED);
+    //             update_producer_blocks(producer, 1, totalMissedSlots);
+    //         }
+    //     }
     }    
 
     _grotations.last_time_block_produced = timestamp;
@@ -183,7 +183,11 @@ void system_contract::onblock(block_timestamp timestamp, account_name producer) 
         });
     }
 
-    check_missed_blocks(timestamp, producer);
+    if (_grotations.is_kick_active) {
+        check_missed_blocks(timestamp, producer);
+    }
+
+    //check_missed_blocks(timestamp, producer);
 
     // Only update block producers once every minute, block_timestamp is in half seconds
     if (timestamp.slot - _gstate.last_producer_schedule_update.slot > 120) {

--- a/contracts/eosio.system/producer_pay.cpp
+++ b/contracts/eosio.system/producer_pay.cpp
@@ -72,7 +72,7 @@ void system_contract::set_producer_block_missed(account_name producer, uint32_t 
   if (pitr != _producers.end() && pitr->active()) {
     _producers.modify(pitr, 0, [&](auto &p) {
         p.missed_blocks += amount;
-        if(crossed_missed_blocks_threshold(p.missed_blocks)) p.deactivate();
+        if(crossed_missed_blocks_threshold(p.missed_blocks) && _grotations.is_kick_active) p.deactivate();
     });
   }
 }
@@ -83,7 +83,7 @@ void system_contract::update_producer_blocks(account_name producer, uint32_t amo
       _producers.modify(pitr, 0, [&](auto &p) { 
         p.blocks_per_cycle += amountBlocksProduced; 
         p.missed_blocks += amountBlocksMissed;
-        if(crossed_missed_blocks_threshold(p.missed_blocks)) p.deactivate();
+        if(crossed_missed_blocks_threshold(p.missed_blocks) && _grotations.is_kick_active) p.deactivate();
       });
   }
 }

--- a/contracts/eosio.system/voting.cpp
+++ b/contracts/eosio.system/voting.cpp
@@ -86,7 +86,7 @@ namespace eosiosystem {
       _grotations.last_rotation_time = block_time;
       _grotations.next_rotation_time = block_timestamp(block_time.to_time_point() + time_point(microseconds(SIX_HOURS_US)));
    } 
-
+   //TODO: Add _grotations.is_rotation_active, that way this feature can be toggled.
    void system_contract::update_elected_producers( block_timestamp block_time ) {
       _gstate.last_producer_schedule_update = block_time;
 

--- a/contracts/eosio.system/voting.cpp
+++ b/contracts/eosio.system/voting.cpp
@@ -21,6 +21,7 @@
 #define VOTE_VARIATION 0.1
 #define TWELVE_HOURS_US 43200000000
 #define SIX_MINUTES_US 360000000 // debug version
+#define TWELVE_MINUTES_US 720000000
 #define SIX_HOURS_US 21600000000
 #define MAX_PRODUCERS 51
 #define TOP_PRODUCERS 21
@@ -84,7 +85,7 @@ namespace eosiosystem {
 
    void system_contract::updateRotationTime(block_timestamp block_time){
       _grotations.last_rotation_time = block_time;
-      _grotations.next_rotation_time = block_timestamp(block_time.to_time_point() + time_point(microseconds(SIX_HOURS_US)));
+      _grotations.next_rotation_time = block_timestamp(block_time.to_time_point() + time_point(microseconds(TWELVE_MINUTES_US)));
    } 
    //TODO: Add _grotations.is_rotation_active, that way this feature can be toggled.
    void system_contract::update_elected_producers( block_timestamp block_time ) {

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -154,6 +154,30 @@ struct onerror {
    }
 };
 
+struct setkick {
+    bool state;
+
+    static account_name get_account() {
+      return N(eosio);
+    }
+
+   static action_name get_name() {
+      return N(setkick);
+   }
+};
+
+struct setrotate {
+    bool state;
+
+    static account_name get_account() {
+      return N(eosio);
+    }
+
+   static action_name get_name() {
+      return N(setrotate);
+   }
+};
+
 } } /// namespace eosio::chain
 
 FC_REFLECT( eosio::chain::newaccount                       , (creator)(name)(owner)(active) )
@@ -165,3 +189,4 @@ FC_REFLECT( eosio::chain::linkauth                         , (account)(code)(typ
 FC_REFLECT( eosio::chain::unlinkauth                       , (account)(code)(type) )
 FC_REFLECT( eosio::chain::canceldelay                      , (canceling_auth)(trx_id) )
 FC_REFLECT( eosio::chain::onerror                          , (sender_id)(sent_trx) )
+FC_REFLECT( eosio::chain::setkick                          , (state) )

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -151,9 +151,7 @@ namespace eosio { namespace testing {
                                      permission_name parent = config::owner_name );
          void delete_authority( account_name account, permission_name perm,  const vector<permission_level>& auths, const vector<private_key_type>& keys );
          void delete_authority( account_name account, permission_name perm );
-         transaction_trace_ptr set_kick(bool state);
-         transaction_trace_ptr set_rotate(bool state);
-
+         
          transaction_trace_ptr create_account( account_name name,
                                                account_name creator = config::system_account_name,
                                                bool multisig = false,

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -151,6 +151,8 @@ namespace eosio { namespace testing {
                                      permission_name parent = config::owner_name );
          void delete_authority( account_name account, permission_name perm,  const vector<permission_level>& auths, const vector<private_key_type>& keys );
          void delete_authority( account_name account, permission_name perm );
+         transaction_trace_ptr set_kick(bool state);
+         transaction_trace_ptr set_rotate(bool state);
 
          transaction_trace_ptr create_account( account_name name,
                                                account_name creator = config::system_account_name,

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -110,32 +110,6 @@ namespace eosio { namespace testing {
          push_genesis_block();
    }
 
-   transaction_trace_ptr base_tester::set_kick(bool state) {
-        signed_transaction trx;
-        set_transaction_headers(trx);
-        trx.actions.emplace_back( vector<permission_level>{{N(eosio),config::active_name}},
-                                setkick{
-                                   .state  = state
-                                });
-
-      set_transaction_headers(trx);
-      trx.sign( get_private_key( N(eosio), "active" ), control->get_chain_id()  );
-      return push_transaction( trx );
-   }
-
-//    transaction_trace_ptr base_tester::set_rotate(bool state) {
-//         signed_transaction trx;
-//         set_transaction_headers(trx);
-//         trx.actions.emplace_back( vector<permission_level>{{N(eosio),config::active_name}},
-//                                 setrotate{
-//                                    .state  = state
-//                                 });
-
-//       set_transaction_headers(trx);
-//       trx.sign( get_private_key( N(eosio), "active" ), control->get_chain_id()  );
-//       return push_transaction( trx );
-//    }
-
    void base_tester::init(controller::config config) {
       cfg = config;
       open();

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -110,6 +110,31 @@ namespace eosio { namespace testing {
          push_genesis_block();
    }
 
+   transaction_trace_ptr base_tester::set_kick(bool state) {
+        signed_transaction trx;
+        set_transaction_headers(trx);
+        trx.actions.emplace_back( vector<permission_level>{{N(eosio),config::active_name}},
+                                setkick{
+                                   .state  = state
+                                });
+
+      set_transaction_headers(trx);
+      trx.sign( get_private_key( N(eosio), "active" ), control->get_chain_id()  );
+      return push_transaction( trx );
+   }
+
+   transaction_trace_ptr base_tester::set_rotate(bool state) {
+        signed_transaction trx;
+        set_transaction_headers(trx);
+        trx.actions.emplace_back( vector<permission_level>{{N(eosio),config::active_name}},
+                                setrotate{
+                                   .state  = state
+                                });
+
+      set_transaction_headers(trx);
+      trx.sign( get_private_key( N(eosio), "active" ), control->get_chain_id()  );
+      return push_transaction( trx );
+   }
 
    void base_tester::init(controller::config config) {
       cfg = config;
@@ -121,7 +146,6 @@ namespace eosio { namespace testing {
       control.reset();
       chain_transactions.clear();
    }
-
 
    void base_tester::open() {
       control.reset( new controller(cfg) );

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -123,18 +123,18 @@ namespace eosio { namespace testing {
       return push_transaction( trx );
    }
 
-   transaction_trace_ptr base_tester::set_rotate(bool state) {
-        signed_transaction trx;
-        set_transaction_headers(trx);
-        trx.actions.emplace_back( vector<permission_level>{{N(eosio),config::active_name}},
-                                setrotate{
-                                   .state  = state
-                                });
+//    transaction_trace_ptr base_tester::set_rotate(bool state) {
+//         signed_transaction trx;
+//         set_transaction_headers(trx);
+//         trx.actions.emplace_back( vector<permission_level>{{N(eosio),config::active_name}},
+//                                 setrotate{
+//                                    .state  = state
+//                                 });
 
-      set_transaction_headers(trx);
-      trx.sign( get_private_key( N(eosio), "active" ), control->get_chain_id()  );
-      return push_transaction( trx );
-   }
+//       set_transaction_headers(trx);
+//       trx.sign( get_private_key( N(eosio), "active" ), control->get_chain_id()  );
+//       return push_transaction( trx );
+//    }
 
    void base_tester::init(controller::config config) {
       cfg = config;

--- a/unittests/eosio.system_tests.cpp
+++ b/unittests/eosio.system_tests.cpp
@@ -1219,7 +1219,7 @@ BOOST_FIXTURE_TEST_CASE( proxy_actions_affect_producers, eosio_system_tester, * 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::tolerance(1e-10)) try {
-
+      
    const double usecs_per_year  = 52 * 7 * 24 * 3600 * 1000000ll;
    const double secs_per_year   = 52 * 7 * 24 * 3600;
    const double continuous_rate = 0.025; 
@@ -1258,6 +1258,9 @@ BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::t
 
       prod = get_producer_info("defproducera");
       const uint32_t unpaid_blocks = prod["unpaid_blocks"].as<uint32_t>();
+      const bool is_active = prod["is_active"].as<bool>();
+      std::cout << "Producer defproducera unpaid_blocks: " << unpaid_blocks << " Is it greater than 1: " << (1 < unpaid_blocks) << std::endl;
+      std::cout << "Producer defproducera is_active: " << is_active << std::endl;
       BOOST_REQUIRE(1 < unpaid_blocks);
       BOOST_REQUIRE_EQUAL(0, prod["last_claim_time"].as<uint64_t>());
 
@@ -2389,7 +2392,6 @@ BOOST_FIXTURE_TEST_CASE( bid_invalid_names, eosio_system_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
-
    const std::string not_closed_message("auction for name is not closed yet");
 
    std::vector<account_name> accounts = { N(alice), N(bob), N(carl), N(david), N(eve) };
@@ -2527,7 +2529,6 @@ BOOST_FIXTURE_TEST_CASE( multiple_namebids, eosio_system_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( vote_producers_in_and_out, eosio_system_tester ) try {
-
    const asset net = core_from_string("80.0000");
    const asset cpu = core_from_string("80.0000");
    std::vector<account_name> voters = { N(producvotera), N(producvoterb), N(producvoterc), N(producvoterd) };

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -590,6 +590,7 @@ BOOST_FIXTURE_TEST_CASE(cpu_usage_tests, tester ) try {
 // test weighted cpu limit
 BOOST_FIXTURE_TEST_CASE(weighted_cpu_limit_tests, tester ) try {
 // TODO Increase the robustness of this test.
+   setkick(false);
    resource_limits_manager mgr = control->get_mutable_resource_limits_manager();
    create_accounts( {N(f_tests)} );
    create_accounts( {N(acc2)} );

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -590,7 +590,6 @@ BOOST_FIXTURE_TEST_CASE(cpu_usage_tests, tester ) try {
 // test weighted cpu limit
 BOOST_FIXTURE_TEST_CASE(weighted_cpu_limit_tests, tester ) try {
 // TODO Increase the robustness of this test.
-   setkick(false);
    resource_limits_manager mgr = control->get_mutable_resource_limits_manager();
    create_accounts( {N(f_tests)} );
    create_accounts( {N(acc2)} );


### PR DESCRIPTION
This includes new functions that allows unit testing environments to disable the BP automatic kick features of the eosio.system contract. Allowing unit tests to succeed.