### PR TITLE
Trail refactor

### DIFF
--- a/contracts/trail.service/README.md
+++ b/contracts/trail.service/README.md
@@ -1,0 +1,44 @@
+# Trail Walkthrough
+
+Trail offers a comprehensive suite of blockchain-based services.
+
+## Voting and Ballot/Voter Registration
+
+All users on the Telos Blockchain Network can register their account and receive a VoterID card that can be used in any Ballot or Election running on Trail. Developers can easily integrate with Trail by including the `trailconn.voting.hpp` plugin in their contracts.
+
+### Voting Actions
+
+* `regvoter()`
+
+    Calling regvoter will affiliate the given account_name with the given token symbol.
+
+* `unregvoter()`
+
+    Calling unregvoter will remove the registration from the table.
+
+* `addreceipt()`
+
+    The addreceipt function is called as an inline action by the external voting contract. This action should only be called when a vote has been deemed valid (criteria for validity is at the discretion of the developer), and the vote is ready to be logged. Once validation passes, the inline action should store the code, scope, and key of the data object for which the vote was cast.
+
+* `rmvexpvotes()`
+
+    The rmvexpreceipts action is called by the owner of a VoterID to remove all expired receipts still logged on their VoterID.
+
+* `regballot()`
+
+    RegBallot is called to register a voting contract.
+
+* `unregballot()`
+
+    Unregballot is called to remove a registered voting contract from the table.
+
+## Token Registration
+
+Developers and organizations can author new and independent token contracts and then register their contract through Trail. Registering a token 
+
+* `regtoken()`
+* `unregtoken()`
+
+## Trailconn Definitions
+
+## Teclos Example Commands

--- a/contracts/trail.service/README.md
+++ b/contracts/trail.service/README.md
@@ -34,7 +34,7 @@ All users on the Telos Blockchain Network can register their account and receive
 
 ## Token Registration
 
-Developers and organizations can author new and independent token contracts and then register their contract through Trail. Registering a token 
+Developers and organizations can author new and independent token contracts and then register their contract through Trail.
 
 * `regtoken()`
 * `unregtoken()`

--- a/contracts/trail.service/trail.connections/trailconn.system.hpp
+++ b/contracts/trail.service/trail.connections/trailconn.system.hpp
@@ -1,0 +1,55 @@
+/**
+ * This file includes all definitions necessary to interact with the system contract. Developers who want to
+ * utilize this system simply must include this file in their implementation to interact with the information
+ * stored by Trail.
+ * 
+ * @author Craig Branscom
+ */
+
+#include <eosiolib/eosio.hpp>
+#include <eosiolib/permission.hpp>
+#include <eosiolib/asset.hpp>
+#include <eosiolib/action.hpp>
+#include <eosiolib/types.hpp>
+#include <eosiolib/singleton.hpp>
+
+using namespace std;
+using namespace eosio;
+
+struct account {
+    asset    balance;
+
+    uint64_t primary_key() const { return balance.symbol.name(); }
+};
+
+struct currency_stats {
+    asset          supply;
+    asset          max_supply;
+    account_name   issuer;
+
+    uint64_t primary_key() const { return supply.symbol.name(); }
+};
+
+struct transfer_args {
+    account_name  from;
+    account_name  to;
+    asset         quantity;
+    string        memo;
+};
+
+typedef eosio::multi_index<N(accounts), account> accounts;
+typedef eosio::multi_index<N(stat), currency_stats> stats;
+
+int64_t get_liquid_tlos(account_name voter) {
+    accounts accountstable(N(eosio.token), voter);
+    auto a = accountstable.find(asset(int64_t(0), S(4, TLOS)).symbol.name()); //TODO: find better way to get TLOS symbol?
+
+    int64_t liquid_tlos = 0;
+
+    if (a != accountstable.end()) {
+        auto acct = *a;
+        liquid_tlos = acct.balance.amount / int64_t(10000); //divide to get actual balance
+    }
+    
+    return liquid_tlos;
+}

--- a/contracts/trail.service/trail.connections/trailconn.tokens.hpp
+++ b/contracts/trail.service/trail.connections/trailconn.tokens.hpp
@@ -1,0 +1,28 @@
+/**
+ * This file includes all definitions necessary to interact with Trail's token registration system. Developers 
+ * who want to utilize the system simply must include this file in their implementation to interact with the 
+ * information stored by Trail.
+ * 
+ * @author Craig Branscom
+ */
+
+#include <eosiolib/eosio.hpp>
+#include <eosiolib/permission.hpp>
+#include <eosiolib/asset.hpp>
+#include <eosiolib/action.hpp>
+#include <eosiolib/types.hpp>
+#include <eosiolib/singleton.hpp>
+
+using namespace std;
+using namespace eosio;
+
+/// @abi table registries i64
+struct registration {
+    asset native;
+    account_name publisher;
+
+    uint64_t primary_key() const { return native.symbol.name(); }
+    uint64_t by_publisher() const { return publisher; }
+};
+
+typedef multi_index<N(registries), registration> registries_table;

--- a/contracts/trail.service/trail.connections/trailconn.voting.hpp
+++ b/contracts/trail.service/trail.connections/trailconn.voting.hpp
@@ -78,31 +78,3 @@ struct ballot {
 typedef multi_index<N(voters), voterid> voters_table;
 typedef multi_index<N(ballots), ballot> ballots_table;
 typedef singleton<N(environment), environment> environment_singleton;
-
-//----------EOSIO.TOKEN DEFINITIONS----------
-
-struct account {
-    asset balance;
-
-    uint64_t primary_key()const { return balance.symbol.name(); }
-};
-
-typedef eosio::multi_index<N(accounts), account> accounts;
-
-/**
- * Updates the voter's tlos_weight on their VoterID.
- * @param voter - account from which to retrieve liquid TLOS amount
-*/
-int64_t get_liquid_tlos(account_name voter) {
-    accounts accountstable(N(eosio.token), voter);
-    auto a = accountstable.find(asset(int64_t(0), S(4, TLOS)).symbol.name()); //TODO: find better way to get TLOS symbol?
-
-    int64_t liquid_tlos = 0;
-
-    if (a != accountstable.end()) {
-        auto acct = *a;
-        liquid_tlos = acct.balance.amount / int64_t(10000); //divide to get actual balance
-    }
-    
-    return liquid_tlos;
-}

--- a/contracts/trail.service/trail.service.cpp
+++ b/contracts/trail.service/trail.service.cpp
@@ -26,10 +26,14 @@ void trail::regtoken(asset native, account_name publisher) {
     require_auth(publisher);
 
     auto sym = native.symbol.name();
+
+    stats statstable(N(eosio.token), sym);
+    auto eosio_existing = statstable.find(sym);
+    eosio_assert(eosio_existing == statstable.end(), "Token with symbol already exists in eosio.token" );
+
     registries_table registries(_self, sym);
     auto r = registries.find(sym);
-
-    eosio_assert(r == registries.end(), "Token Registry with that symbol already exists.");
+    eosio_assert(r == registries.end(), "Token Registry with that symbol already exists in Trail");
 
     registries.emplace(publisher, [&]( auto& a ){
         a.native = native;
@@ -241,65 +245,4 @@ void trail::unregballot(account_name publisher) {
     print("\nBallot Unregistration: SUCCESS");
 }
 
-/*
-extern "C" {
-    void apply(uint64_t self, uint64_t code, uint64_t action) {
-        trail _trail(self);
-
-        //has_auth(N(accountname)) //?
-        //ballots_table ballots(self, code); //check that code is from a ballot
-
-        if (code == self && action == N(regtoken)) {
-            execute_action(&_trail, &trail::regtoken);
-        } else if (code == self && action == N(unregtoken)) {
-            execute_action(&_trail, &trail::unregtoken);
-        } else if (code == self && action == N(regvoter)) {
-            execute_action( &_trail, &trail::regvoter);
-        } else if (code == self && action == N(unregvoter)) {
-            execute_action(&_trail, &trail::unregvoter);
-        } else if (code == self && action == N(addreceipt)) { //add code condition
-            //print("\nreceiver: ", name{self});
-            //print("\ncode: ", name{code});
-            //print("\naction: ", name{action});
-            execute_action(&_trail, &trail::addreceipt);
-        } else if (code == self && action == N(regballot)) {
-            execute_action(&_trail, &trail::regballot);
-        } else if (code == self && action == N(unregballot)) {
-            execute_action(&_trail, &trail::unregballot);
-        }
-    }
-};
-*/
-
-/*
-extern "C" {
-    void apply(uint64_t receiver, uint64_t code, uint64_t action) {
-        switch(action) {
-            case N(trailvote): return addreceipt(receiver, code);
-        }
-    }
-}
-*/
-
-/*
-extern "C" {
-    void apply(uint64_t receiver, uint64_t code, uint64_t action) {
-        auto self = receiver;
-        if(code == self){
-            trail _trail(self);
-            switch(action){
-      	        case N(regtoken): execute_action(&_trail, &trail::regtoken);
-                case N(unregtoken): execute_action(&_trail, &trail::unregtoken);
-                case N(regvoter): execute_action(&_trail, &trail::regvoter);
-                case N(unregvoter): execute_action(&_trail, &trail::unregvoter);
-                case N(addreceipt): execute_action(&_trail, &trail::addreceipt);
-                case N(rmvreceipt): execute_action(&_trail, &trail::rmvreceipt);
-                case N(regballot): execute_action(&_trail, &trail::regballot);
-                case N(unregballot): execute_action(&_trail, &trail::unregballot);
-            }
-        }
-    }
-};
-*/
-
-EOSIO_ABI(trail, (regtoken)(unregtoken)(regvoter)(unregvoter)(addreceipt)(rmvexpvotes))
+EOSIO_ABI(trail, (regtoken)(unregtoken)(regvoter)(unregvoter)(addreceipt)(rmvexpvotes)(regballot)(unregballot))

--- a/contracts/trail.service/trail.service.hpp
+++ b/contracts/trail.service/trail.service.hpp
@@ -1,6 +1,13 @@
+/**
+ * 
+ * 
+ */
+
 #pragma once
 
-#include <trail.connections/trailconn.voting.hpp> //Import trailservice voting data definitions
+#include <trail.connections/trailconn.voting.hpp>
+#include <trail.connections/trailconn.system.hpp>
+#include <trail.connections/trailconn.tokens.hpp>
 
 #include <eosiolib/asset.hpp>
 #include <eosiolib/eosio.hpp>
@@ -10,8 +17,8 @@
 using namespace eosio;
 
 class trail : public contract {
+    
     public:
-
         /**
          * Constructor sets environment singleton upon contract deployment, and gets environment for every action call.
         */
@@ -76,17 +83,6 @@ class trail : public contract {
         void unregballot(account_name publisher);
 
     protected:
-
-        /// @abi table registries i64
-        struct registration {
-            asset native;
-            account_name publisher;
-
-            uint64_t primary_key() const { return native.symbol.name(); }
-            uint64_t by_publisher() const { return publisher; }
-        };
-
-        typedef multi_index<N(registries), registration> registries_table;
 
         environment_singleton env_singleton;
         environment env_struct;


### PR DESCRIPTION
This PR refactors all of the definitions used by Trail into separate files.

Also includes a bug fix for the regtoken() action. Regtoken now checks against the stat table of eosio.token to ensure duplicate token symbols aren't registered.